### PR TITLE
Set style after search bar element is available

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -89,10 +89,12 @@ $(document).ready(function() {
     $.ajax({
         url: 'api/search',
         type: 'HEAD',
-        success: function() {
+        success: function showSearchField() {
             const field = getSearchField();
             if (field) {
                 field.style.display = null;
+            } else {
+                setTimeout(showSearchField, 500);
             }
         },
     });


### PR DESCRIPTION
If the search bar element isn't available, just set a half-second timeout and look for it again.

Fixes #59 