### PR TITLE
hide the .git directory 

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -73,7 +73,7 @@ func main() {
 	}
 	mx := http.NewServeMux()
 	mx.Handle("/", noCacheLoggingHandler(http.FileServer(http.Dir(*sdir))))
-	mx.HandleFunc("/.git", notFound) // I am so tired of these garbage security "reports"
+	mx.HandleFunc("/.git/", notFound) // I am so tired of these garbage security "reports"
 	mx.HandleFunc("/api/search", srv.search)
 	srv.Handler = mx
 


### PR DESCRIPTION
because these "security researchers" cannot be bothered to read the output from their own stupid tools