### PR TITLE
fixing command for apt repo on beta repo

### DIFF
--- a/beta/index.md
+++ b/beta/index.md
@@ -35,7 +35,7 @@ apt install apt-transport-https gnupg wget
 wget -O /usr/share/keyrings/gravwell.asc https://update.gravwell.io/debian/update.gravwell.io.gpg.key
 
 # Add the beta repository
-echo 'deb [ arch=amd64 ] https://update.gravwell.io/debianbeta/ community main' | sudo tee /etc/apt/sources.list.d/gravwell.list
+echo 'deb [ arch=amd64 signed-by=/usr/share/keyrings/gravwell.asc ] https://update.gravwell.io/debianbeta/ community main' | sudo tee /etc/apt/sources.list.d/gravwell.list
 
 # Install the package
 apt update


### PR DESCRIPTION
key wasn't referenced in echo command to get beta repo stood up