### PR TITLE
feat: Allow for wider content

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -75,3 +75,17 @@ nav.bd-links p.bd-links__title {
 #logbot-container img {
   background: unset;
 }
+
+@media (min-width: 960px) {
+  .bd-page-width {
+    max-width: 1800px;
+  }
+}
+
+.bd-main .bd-content .bd-article-container {
+  max-width: 100%;
+}
+
+.bd-sidebar-primary {
+  max-width: 380px;
+}


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes allowing the docs page to grow in width with the user's browser window. This should help with some readability issues related to horizontal-scroll / word wrap.