### PR TITLE
updating the docs to show the right default port on netflow ingester

### DIFF
--- a/configuration/docker.md
+++ b/configuration/docker.md
@@ -110,7 +110,7 @@ Note the use of the `-e` flag to set environment variables. This allows us to dy
 The `-p 2055:2055/udp` option forwards UDP port 2055 (Netflow v5 ingest port) from the container to the host. This should make it easier to send Netflow records into the ingest container.
 
 ```{note}
-The netflow ingester is also configured by default to accept IPFIX records over UDP on port 6343. If you wish to ingest IPFIX records too, add `-p 6343:6343/udp` to the command line above.
+The netflow ingester is also configured by default to accept IPFIX records over UDP on port 4739. If you wish to ingest IPFIX records too, add `-p 4739:4739/udp` to the command line above.
 ```
 
 We can verify that the ingester is active by clicking on the Ingesters item in the menu:

--- a/ingesters/netflow.md
+++ b/ingesters/netflow.md
@@ -33,11 +33,11 @@ The Netflow ingester uses the unified global configuration block described in th
 	Flow-Type=ipfix
 ```
 
-```note
+```{note}
 By default the Netflow ingester will listen for both Netflowv5 on UDP port 2055 and NetflowV9/IPFix on UDP port 4379.  It is highly reccomended that one of the listeners is disabled.
 ```
 
-```note
+```{note}
 The default NetflowV9 and/or IPFix port of 4739 is somewhat disagreed upon by major networking manufacturers, some equipment expect to send NetflowV9 traffic to UDP port 6343.  Adjust the configuration file accordingly.
 ```
 

--- a/ingesters/netflow.md
+++ b/ingesters/netflow.md
@@ -29,8 +29,16 @@ The Netflow ingester uses the unified global configuration block described in th
 
 [Collector "ipfix"]
 	Tag-Name=ipfix
-	Bind-String="0.0.0.0:6343"
+	Bind-String="0.0.0.0:4739"
 	Flow-Type=ipfix
+```
+
+```note
+By default the Netflow ingester will listen for both Netflowv5 on UDP port 2055 and NetflowV9/IPFix on UDP port 4379.  It is highly reccomended that one of the listeners is disabled.
+```
+
+```note
+The default NetflowV9 and/or IPFix port of 4739 is somewhat disagreed upon by major networking manufacturers, some equipment expect to send NetflowV9 traffic to UDP port 6343.  Adjust the configuration file accordingly.
 ```
 
 ## Installation

--- a/ingesters/netflow.md
+++ b/ingesters/netflow.md
@@ -38,7 +38,7 @@ By default the Netflow ingester will listen for both Netflowv5 on UDP port 2055 
 ```
 
 ```{note}
-The default NetflowV9 and/or IPFix port of 4739 is somewhat disagreed upon by major networking manufacturers, some equipment expect to send NetflowV9 traffic to UDP port 6343.  Adjust the configuration file accordingly.
+The default NetflowV9 and/or IPFix port of 4739 is somewhat disagreed upon by major networking manufacturers; some equipment expects to send NetflowV9 traffic to UDP port 6343.  Adjust the configuration file accordingly.
 ```
 
 ## Installation


### PR DESCRIPTION
also calling out port used by Cisco and friends

Discord user called out the docs examples weren't matching the defaults in the config which is confusing when starting up.  This makes the docs match the config.