### PR TITLE
feat: Add copy button to code elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,36 @@
-### Gravwell Wiki
+# Gravwell Wiki
+
 Current version of Gravwell documentation can always be found at http://docs.gravwell.io
 This repo is served up at that url and can be cloned for offline use.
 
 There is a shell.nix provided in the repo. To install Nix, visit https://nixos.org/download.html
-Once nix is installed, just run `nix-shell` in the wiki root directory. 
+Once nix is installed, just run `nix-shell` in the wiki root directory.
 
 Inside of the nix-shell:
+
 - build the documentation by running `make html`
 - view changes as you edit by running `make livehtml` and visit http://127.0.0.1:8000
+
+## Adding Sphinx Extensions
+
+Adding a Sphinx extension requires two steps:
+
+- Add relevant Python package(s) to the nix shell
+- Add the extension to `conf.py`
+
+Once the pacakges are installed and listed in `conf.py`, the extension will ready for use.
+
+### Example adding `sphinx-copybutton`
+
+**Adding `sphinx-copybutton` to nix shell**
+
+1. Let's check if the extension is already available in nixpkgs by visiting https://search.nixos.org/packages and searching for sphinx-copybutton
+   - If it's available, note the attribute path: `nixpkgs.python310Packages.sphinx-copybutton`
+   - If it's not available, consult the nix docs for packaging python libs. We package `not-found-extension` ourselves in `package.nix`. That's a good starting point.
+2. Because `sphinx-copybutton` is in nixpkgs, we can just add it to `packages.nix` in the `pythonBundle`.
+3. Exit (if necessary) then re-enter the nix shell with `nix-shell`
+
+**Adding `sphinx-copybutton` to `conf.py`**
+
+1. Consult the docs. Looks like copy button just requires adding `"sphinx_copybutton"` to the list of extensions in `conf.py`.
+2. Run `black conf.py` to format the file

--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -89,3 +89,20 @@ nav.bd-links p.bd-links__title {
 .bd-sidebar-primary {
   max-width: 380px;
 }
+
+div.docutils  {
+    position: relative;
+}
+
+/* Show the copybutton */
+div.docutils:hover button.copybtn, button.copybtn.success {
+	opacity: 1;
+}
+
+div.docutils button.copybtn:hover {
+    background-color: rgb(235, 235, 235);
+}
+
+div.docutils button.copybtn:active {
+    background-color: rgb(187, 187, 187);
+}

--- a/conf.py
+++ b/conf.py
@@ -30,6 +30,7 @@ extensions = [
     "myst_parser",
     "sphinx_design",
     "notfound.extension",
+    "sphinx_copybutton",
 ]
 
 myst_enable_extensions = [
@@ -131,3 +132,6 @@ html_context = {
 
 # Variables to substitute in Markdown files
 myst_substitutions = {}
+
+# Copy button
+copybutton_selector = "div.highlight pre,div.docutils pre.literal-block"

--- a/ingesters/installation_instructions_template
+++ b/ingesters/installation_instructions_template
@@ -1,20 +1,26 @@
 To install the Debian package, make sure the Gravwell Debian repository is configured [as described in the quickstart](debian_repo). Then run the following command as root:
 
+:::::{div}
 ::: {parsed-literal}
 apt update && apt install {{package}}
 :::
+:::::
 
 To install the Redhat package, make sure the Gravwell Redhat repository is configured [as described in the quickstart](redhat_repo). Then run the following command as root:
 
+:::::{div}
 ::: {parsed-literal}
 yum install {{package}}
 :::
+:::::
 
 To install via the standalone shell installer, download the installer from the [downloads page](/quickstart/downloads), then run the following command as root, replacing X.X.X with the appropriate version:
 
+:::::{div}
 ::: {parsed-literal}
 bash {{standalone}}_installer_X.X.X.sh
 :::
+:::::
 
 You may be prompted for additional configuration during the installation.
 

--- a/packages.nix
+++ b/packages.nix
@@ -28,6 +28,7 @@ let
     with ps; [
       sphinx
       sphinx-autobuild
+      sphinx-copybutton
       myst-parser
       pydata-sphinx-theme
       sphinx-design


### PR DESCRIPTION
This PR addresses #655 

This PR proposes adding a "copy" button to...

- the `<pre>` command blocks on ingester pages that show install instructions
- all other code blocks

The relevant issue requests that the command work on the command blocks, but I figured it might not hurt to expand the scope to other config stuff as well. It's pretty convenient to just click-to-copy config chunks.