### PR TITLE
fix: broken link in changelog

### DIFF
--- a/changelog/5.2.2.md
+++ b/changelog/5.2.2.md
@@ -5,7 +5,7 @@
 ## New Additions
 
 * New [Trim search modules](/search/trim/trim) added.
-* New [Syslog Router preprocessor](ingesters/preprocessors/syslogrouter).
+* New [Syslog Router preprocessor](/ingesters/preprocessors/syslogrouter).
 * Added `Required-Retention` <a href="/configuration/ageout.html#forcing-a-required-retention-period">flag</a> for ageout configuration.
 * Added `-maxtracked` <a href="/search/stats/stats.html#the-maxtracked-flag">flag</a> for Unique and Stats modules.
 * Added `has()` builtin to [eval](/search/eval/eval). 


### PR DESCRIPTION
This PR addresses no issue. Fixes broken link for Syslog Router preprocessor in changelog