### PR TITLE
fix(#747, #748): promote downloads + remove .md from links

### DIFF
--- a/configuration/archive.md
+++ b/configuration/archive.md
@@ -67,7 +67,7 @@ On Redhat:
 yum install gravwell-cloudarchive-server
 ```
 
-As a standalone shell installer (downloaded from [the downloads page](/quickstart/downloads.md)):
+As a standalone shell installer (downloaded from [the downloads page](/quickstart/downloads)):
 
 ```
 sh gravwell_cloudarchive_server_installer_x.x.x.sh

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 # Gravwell Docs
 
-This site contains documentation for Gravwell, plus other resources such as Changelogs.
+This site contains documentation for Gravwell, plus other resources such as [Downloads](quickstart/downloads) and [Release Notes](changelog/list).
 
 If you're just starting out with Gravwell, we recommend reading the [Quick Start](quickstart/quickstart) first, then moving on to the [Search pipeline](search/search) documentation to learn more.
 
@@ -17,6 +17,7 @@ Configuration <architecture/architecture>
 Ingesters <ingesters/ingesters>
 Searching with Gravwell <gravwell>
 Automation <automation>
+Downloads <quickstart/downloads>
 API <api/api>
 Release Notes <changelog/list>
 ```

--- a/ingesters/ingesters.md
+++ b/ingesters/ingesters.md
@@ -27,7 +27,6 @@ Azure Event Hubs <eventhubs>
 collectd <collectd>
 Federator <federators/federator>
 File Follower <file_follow>
-Windows File Follower <win_file_follow>
 GCP PubSub <pubsub>
 HTTP <http>
 IPMI <ipmi>
@@ -45,6 +44,7 @@ Shodan <shodan>
 Simple Relay <simple_relay>
 SNMP Trap <snmp>
 Windows Events <winevent>
+Windows File Follower <win_file_follow>
 ```
 
 | Ingester | Description |
@@ -53,7 +53,6 @@ Windows Events <winevent>
 | [Azure Event Hubs](eventhubs) | Consume from Azure Event Hubs. |
 | [collectd](collectd) | Ingest collectd samples. |
 | [File Follower](file_follow) | Watch and ingest files on disk, such as logs. |
-| [Windows File Follower](win_file_follow) | Watch and ingest files on Windows, such as logs and EVTX files. |
 | [GCP PubSub](pubsub) | Fetch and ingest entries from Google Compute Platform PubSub Streams. |
 | [HTTP](http) | Create HTTP listeners on multiple URL paths. |
 | [IPMI](ipmi) | Periodically collect SDR and SEL records from IPMI devices. |
@@ -70,6 +69,7 @@ Windows Events <winevent>
 | [Simple Relay](simple_relay) | Ingest any text over TCP/UDP, syslog, and more. |
 | [SNMP Trap](snmp) | Receive and ingest SNMP trap messages. |
 | [Windows Events](winevent) | Collect Windows events. |
+| [Windows File Follower](win_file_follow) | Watch and ingest files on Windows, such as logs and EVTX files. |
 
 
 ## Tags

--- a/ingesters/win_file_follow.md
+++ b/ingesters/win_file_follow.md
@@ -8,6 +8,12 @@ The most common use case for File Follower is monitoring a directory containing 
 Do not use the file follower to follow actively written EVTX files on a Windows system; the kernel does not produce inotify events on these EVTX files.  The [Windows event ingester](/ingesters/winevent) is a better option for pulling in live event logs.
 ```
 
+## Installer
+
+| Ingester Name | Installer    | More Info |
+| :------------ | :----------- | :-------- |
+| Windows File Follower | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_file_follow_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">d8d4d924c6ecc17e14d6a869a895b561ca8448f3c4ea7da0fbf0b19b3d62a799</span></code>'>(SHA256)</a> | [Documentation](/ingesters/win_file_follow) |
+
 ## Installation
 
 The Gravwell Windows file follower is installed using a signed MSI package.  Gravwell signs both the Windows executable and MSI installer with our private key pairs, but depending on download volumes, you may see a warning about the MSI being untrusted.  This is due to the way Microsoft "weighs" files.   Basically, as they see more people download and install a given package, it becomes more trustworthy.  Don't worry though, we have a well audited build pipeline and we sign every package.

--- a/ingesters/win_file_follow.md
+++ b/ingesters/win_file_follow.md
@@ -8,13 +8,13 @@ The most common use case for File Follower is monitoring a directory containing 
 Do not use the file follower to follow actively written EVTX files on a Windows system; the kernel does not produce inotify events on these EVTX files.  The [Windows event ingester](/ingesters/winevent) is a better option for pulling in live event logs.
 ```
 
-## Installer
+## Installation
+
+Download the Gravwell Windows File Follower installer: 
 
 | Ingester Name | Installer    | More Info |
 | :------------ | :----------- | :-------- |
 | Windows File Follower | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_file_follow_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">d8d4d924c6ecc17e14d6a869a895b561ca8448f3c4ea7da0fbf0b19b3d62a799</span></code>'>(SHA256)</a> | [Documentation](/ingesters/win_file_follow) |
-
-## Installation
 
 The Gravwell Windows file follower is installed using a signed MSI package.  Gravwell signs both the Windows executable and MSI installer with our private key pairs, but depending on download volumes, you may see a warning about the MSI being untrusted.  This is due to the way Microsoft "weighs" files.   Basically, as they see more people download and install a given package, it becomes more trustworthy.  Don't worry though, we have a well audited build pipeline and we sign every package.
 

--- a/ingesters/winevent.md
+++ b/ingesters/winevent.md
@@ -2,6 +2,13 @@
 
 The Gravwell Windows events ingester runs as a service on a Windows machine and sends Windows events to the Gravwell indexer.  The ingester consumes from the `System`, `Application`, `Setup`, and `Security` channels by default.  Each channel can be configured to consume from a specific set of events or providers.
 
+## Installer
+
+| Ingester Name | Installer    | More Info |
+| :------------ | :----------- | :-------- |
+| Windows Events | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_win_events_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">1da0cd7e0e76fdd8d5eece8e00d359f543a06e88901a453a4893fc11adb828fa</span></code>'>(SHA256)</a> | [Documentation](/ingesters/winevent) |
+
+
 ## Basic Configuration
 
 The Windows Event ingester uses the unified global configuration block described in the [ingester section](ingesters_global_configuration_parameters).  Like most other Gravwell ingesters, the Windows Event ingester supports multiple upstream indexers, TLS, cleartext, and named pipe connections, a local cache, and local logging.

--- a/ingesters/winevent.md
+++ b/ingesters/winevent.md
@@ -2,13 +2,6 @@
 
 The Gravwell Windows events ingester runs as a service on a Windows machine and sends Windows events to the Gravwell indexer.  The ingester consumes from the `System`, `Application`, `Setup`, and `Security` channels by default.  Each channel can be configured to consume from a specific set of events or providers.
 
-## Installer
-
-| Ingester Name | Installer    | More Info |
-| :------------ | :----------- | :-------- |
-| Windows Events | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_win_events_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">1da0cd7e0e76fdd8d5eece8e00d359f543a06e88901a453a4893fc11adb828fa</span></code>'>(SHA256)</a> | [Documentation](/ingesters/winevent) |
-
-
 ## Basic Configuration
 
 The Windows Event ingester uses the unified global configuration block described in the [ingester section](ingesters_global_configuration_parameters).  Like most other Gravwell ingesters, the Windows Event ingester supports multiple upstream indexers, TLS, cleartext, and named pipe connections, a local cache, and local logging.
@@ -52,7 +45,11 @@ The Windows Event ingester uses the unified global configuration block described
 
 ## Installation
 
-Download the Gravwell Windows ingester installer from the [Downloads page](/quickstart/downloads).
+Download the Gravwell Windows Events installer: 
+
+| Ingester Name | Installer    | More Info |
+| :------------ | :----------- | :-------- |
+| Windows Events | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_win_events_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">1da0cd7e0e76fdd8d5eece8e00d359f543a06e88901a453a4893fc11adb828fa</span></code>'>(SHA256)</a> | [Documentation](/ingesters/winevent) |
 
 Run the .msi installation wizard to install the Gravwell events service.  On first installation the installation wizard will prompt to configure the indexer endpoint and ingest secret.  Subsequent installations and/or upgrades will identify a resident configuration file and will not prompt.
 

--- a/quickstart/downloads.md
+++ b/quickstart/downloads.md
@@ -1,20 +1,30 @@
 # Downloads
 
+## Windows Ingesters
+
+| Ingester Name | Installer    | More Info |
+| :------------ | :----------- | :-------- |
+| Windows Events | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_win_events_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">1da0cd7e0e76fdd8d5eece8e00d359f543a06e88901a453a4893fc11adb828fa</span></code>'>(SHA256)</a> | [Documentation](/ingesters/winevent) |
+| Windows File Follower | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_file_follow_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">d8d4d924c6ecc17e14d6a869a895b561ca8448f3c4ea7da0fbf0b19b3d62a799</span></code>'>(SHA256)</a> | [Documentation](/ingesters/win_file_follow) |
+
+
+## Other Installers
+
 ```{attention}
 The Debian and RHEL repositories are more easily maintained than these standalone installers and are the recommended methods of installation. See the [quickstart instructions](quickstart).
 ```
 
-## Gravwell Core
+### Gravwell Core
 
 The Gravwell core installer contains the indexer and webserver frontend. You'll need a license; either get a Community Edition free license, or contact info@gravwell.io for commercial options.
 
 Download Gravwell Core Installer <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">46c4d898ca7076234012cc666872a3e476a0fc85ac4e619b2d7d49f4219c5199</span></code>'>(SHA256)</a>
 
-## Ingesters
+### Ingesters
 
 The core suite of ingesters are available for download as installable packages.  Ingesters designed to operate on Linux machines are typically self contained, statically linked executables that are agnostic to the hosts package management system (with the exception of the NetworkCapture ingester).  Windows based ingesters are distributed as executable MSI packages.  Source code for many ingesters can be found at the [Gravwell Github](https://github.com/gravwell/gravwell/tree/master/ingesters) repository.
 
-### Current Ingester Releases
+#### Current Ingester Releases
 | Ingester Name | Installer    | More Info |
 | :------------ | :----------- | :-------- |
 | Amazon Kinesis | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_kinesis_ingest_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">2dba32dbdadbd867c47c94851e102deabccd5ba5038da4210538bf184bf15ee8</span></code>'>(SHA256)</a> | [Documentation](/ingesters/kinesis)|
@@ -35,17 +45,15 @@ The core suite of ingesters are available for download as installable packages. 
 | Office 365 Logs | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_o365_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">19d5fbc781afc359be0783c9060c3d939ec9f6cb1983cc8c940fe7ec3b7cabac</span></code>'>(SHA256)</a> | [Documentation](/ingesters/o365)|
 | Simple Relay | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_simple_relay_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">03bbbfaecd495cf0f56ff3bda2e18ffd3e147b731ad739e0f239546148b8e477</span></code>'>(SHA256)</a> | [Documentation](/ingesters/simple_relay)|
 | SNMP Traps | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_snmp_ingest_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">209c14e6e1edecfe3ec1e17c9a80cb66cf626c87d0cab6a60a272b2222580e34</span></code>'>(SHA256)</a> | [Documentation](/ingesters/snmp)|
-| Windows Events | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_win_events_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">1da0cd7e0e76fdd8d5eece8e00d359f543a06e88901a453a4893fc11adb828fa</span></code>'>(SHA256)</a> | [Documentation](/ingesters/winevent) |
-| Windows File Follower | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_file_follow_5.3.1.msi"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">d8d4d924c6ecc17e14d6a869a895b561ca8448f3c4ea7da0fbf0b19b3d62a799</span></code>'>(SHA256)</a> | [Documentation](/ingesters/win_file_follow) |
 
-## Other downloads
+### Other downloads
 
 Some Gravwell components are distributed as optional additional installers, such as the search agent and the datastore.
 
 | Component Name | Installer    | More Info |
 | :------------- | :----------- | :-------- |
 | Datastore | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_datastore_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">293b6d0d7a7e0367b1d171d8c5ae1725f5bcfe23ff8c4be70e88895dfdb7df15</span></code>'>(SHA256)</a> | [Documentation](/distributed/frontend) |
-| Cloud Archive Server | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_cloudarchive_server_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">e60fb448ce22679378a9f003d6642ea179237a37030fa618ea87070128d0d9a2</span></code>'>(SHA256)</a> | [Documentation](/configuration/archive.md) |
+| Cloud Archive Server | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_cloudarchive_server_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">e60fb448ce22679378a9f003d6642ea179237a37030fa618ea87070128d0d9a2</span></code>'>(SHA256)</a> | [Documentation](/configuration/archive) |
 | Offline Replicator | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_offline_replication_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">c8e777b46382992e8210b24b8212bba612c01c15169b7751af85db659e770c76</span></code>'>(SHA256)</a> | [Documentation](/configuration/replication) |
 | Load Balancer | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_loadbalancer_installer_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">a3d8c147284eeb10d3bd861f018f4e87a322d7156227c7f8d8c588123049c4f5</span></code>'>(SHA256)</a> | [Documentation](/distributed/loadbalancer) |
 | Gravwell Tools | <a data-custom-class="hash-popover" href="https://update.gravwell.io/archive/5.3.1/installers/gravwell_tools_5.3.1.sh"><i class="fa-solid fa-download"></i></a>&nbsp;&nbsp;&nbsp;<a data-custom-class="hash-popover" href="javascript:void\(0\)" data-toggle="popover" data-placement="bottom" data-html="true" data-content='<code class="docutils literal notranslate"><span class="pre">41f83fc9d23bb177e335605932e765d4360c427cbaf4626eb2a41545bb0f0f2f</span></code>'>(SHA256)</a> | [Documentation](/tools/tools)|

--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -36,7 +36,6 @@ Docker Deployment </configuration/docker>
 Custom Docker Deployments </configuration/custom-docker>
 Gravwell Beta Program </beta/index>
 Gravwell Tools </tools/tools>
-Downloads <downloads>
 ```
 
 ```{toctree}

--- a/search/math/math.md
+++ b/search/math/math.md
@@ -119,4 +119,4 @@ The search above will output every unique combination of IP + port, provided the
 
 The optional `-maxtracked` flag sets the maximum number of unique keys to track per operation, e.g. `unique -maxtracked 5000 DstIP`. This is used to help avoid memory exhaustion if you run `stats count by DstIP` and there are millions of IPv6 addresses in the data. If the maxtracked value is exceeded, the search will terminate with an error suggesting you should increase the max value. Defaults to 100000000.
 
-Refer to the [stats module documentation](/search/stats/stats.md) for more information about maxtracked.
+Refer to the [stats module documentation](/search/stats/stats) for more information about maxtracked.


### PR DESCRIPTION
This PR addresses:
- https://github.com/gravwell/wiki/issues/747
- https://github.com/gravwell/wiki/issues/748

This PR:
- Removes `.md` from links to other pages
- Promotes Downloads to the top nav menu
- Moves API under the More menu option in the top nav
- Adds the link to download installers to the Windows ingester pages only - I did not do this for other ingesters

Please note that you will need to run `make clean` before you run `make html` in order for all of the pages to update properly with the new top nav menu. Maybe you do this already, but wanted to mention it just in case. 
