### PR TITLE
Dynamically show/hide links to improve navbar responsiveness

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -138,21 +138,19 @@ nav.bd-links p.bd-links__title {
   background: unset;
 }
 
-@media (max-width: 959px) {
-  .navbar-brand.logo img {
-    height: 90%;
-  }
+.navbar-brand.logo img {
+  height: 80%;
+  margin-top: 14px;
 }
 
 @media (min-width: 960px) {
   .bd-page-width {
     max-width: 1800px;
   }
+}
 
-  .navbar-brand.logo img {
-    height: 80%;
-    margin-top: 14px;
-  }
+button.btn.version-switcher__button {
+  margin-bottom: unset;
 }
 
 .bd-main .bd-content .bd-article-container {
@@ -180,3 +178,59 @@ div.docutils button.copybtn:hover {
 div.docutils button.copybtn:active {
   background-color: rgb(187, 187, 187);
 }
+
+/*
+
+BEGIN DYNAMIC NAVBAR LINKS
+
+In `dynamic-navbar.html`, we create 8 different navbars.
+
+Each navbar `N` shows `N` links, and puts the remaining `8 - N` links in the "More" dropdown.
+
+The styles below use media queries to dictate which of the 8 navbars will show given the width of the page.
+*/
+
+/* By default, none of the 8 navbars are displayed. */
+.bd-header .navbar-nav.default-hidden-nav {
+  display: none;
+}
+
+/* Depending on the width of the page, we decide which nav to show */
+
+@media (960px <= width < 1035px) {
+  #nav-2 {
+    display: inherit;
+  }
+}
+@media (1035px <= width < 1240px) {
+  #nav-3 {
+    display: inherit;
+  }
+}
+@media (1240px <= width < 1305px) {
+  #nav-4 {
+    display: inherit;
+  }
+}
+@media (1305px <= width < 1430px) {
+  #nav-5 {
+    display: inherit;
+  }
+}
+@media (1430px <= width < 1480px) {
+  #nav-6 {
+    display: inherit;
+  }
+}
+@media (1480px <= width < 1530px) {
+  #nav-7 {
+    display: inherit;
+  }
+}
+@media (min-width: 1530px) {
+  #nav-8 {
+    display: inherit;
+  }
+}
+
+/* END DYNAMIC NAVBAR LINKS */

--- a/_templates/dynamic-navbar.html
+++ b/_templates/dynamic-navbar.html
@@ -1,0 +1,10 @@
+{# Create a bunch of headers that are hidden by default. #}
+{# Use style in custom.css to show at appropriate page widths. #}
+
+{% for i in range(1, 9) %}
+<nav id="nav-{{loop.index}}" class="navbar-nav default-hidden-nav">
+  <ul class="bd-navbar-elements navbar-nav">
+    {{ generate_header_nav_html(n_links_before_dropdown=loop.index, dropdown_text=theme_header_dropdown_text) }}
+  </ul>
+</nav>
+{% endfor %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -21,3 +21,12 @@
   </script>
 
 {% endblock scripts_end %}
+
+{# Search wasn't showing matches because sphinx's searchtools.js wasn't finding role="main" #}
+{# This overrides the docs_boxy block to add the role attribute. Fixes search troubles. #}
+{% block docs_body %}
+  {% include "components/searchbox.html" %}
+  <article class="bd-article" role="main">
+    {% block body %}{% endblock %}
+  </article>
+{% endblock docs_body %}

--- a/_templates/sections/header.html
+++ b/_templates/sections/header.html
@@ -1,0 +1,56 @@
+{#
+    This is basically the original header.html, but with some overridden bootstrap cols to help keep the navbar from wrapping all silly.
+
+    If navbar_start has col-lg-3, the version switcher will wrap in an unpleasant way at certain widths.
+
+    See https://github.com/pydata/pydata-sphinx-theme/blob/6010af1af74db163398092b1f6e721e7da631b02/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+#}
+
+{% if theme_navbar_start or theme_navbar_center or theme_navbar_end or theme_navbar_persistent %}
+<div class="bd-header__inner bd-page-width">
+  <label class="sidebar-toggle primary-toggle" for="__primary">
+    <span class="fa-solid fa-bars"></span>
+  </label>
+  {% set navbar_start, navbar_class, navbar_align = navbar_align_class() %}
+  {% if theme_navbar_start %}
+  <div class="col-xl-3 col-lg-4 navbar-header-items__start">
+    {% for navbar_item in theme_navbar_start %}
+      <div class="navbar-item">{% include navbar_item %}</div>
+    {% endfor %}
+  </div>
+  {% endif %}
+  <div class="col-xl-9 col-lg-8  navbar-header-items">
+    {% if theme_navbar_center %}
+    <div class="{{ navbar_align }} navbar-header-items__center">
+      {% for navbar_item in theme_navbar_center %}
+        <div class="navbar-item">{% include navbar_item %}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    {% if theme_navbar_end or theme_navbar_persistent %}
+    <div class="navbar-header-items__end">
+      {% for navbar_item in theme_navbar_persistent %}
+        <div class="navbar-item navbar-persistent--container">
+          {% include navbar_item %}
+        </div>
+      {% endfor %}
+      {% for navbar_item in theme_navbar_end %}
+        <div class="navbar-item">{% include navbar_item %}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+  {# A search button to show up only on mobile #}
+  {% for navbar_item in theme_navbar_persistent %}
+    <div class="navbar-persistent--mobile">
+      {%- include navbar_item %}
+    </div>
+  {% endfor %}
+
+  {% if not remove_sidebar_secondary and secondary_sidebar_items %}
+    <label class="sidebar-toggle secondary-toggle" for="__secondary" tabindex="0">
+      <span class="fa-solid fa-outdent"></span>
+    </label>
+  {% endif %}
+</div>
+{% endif %}

--- a/conf.py
+++ b/conf.py
@@ -106,6 +106,8 @@ html_theme_options = {
     "check_switcher": False,
     # include the version switcher next to the logo
     "navbar_start": ["navbar-logo", "version-switcher"],
+    # use custom center for navbar, so that we can better manage responsiveness
+    "navbar_center": ["dynamic-navbar"],
 }
 
 # sphinx-favicon


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/wiki/issues/876

This PR proposes:

- Modifying the component that contains header links (`navbar_center`), so that the links in the nav bar hide/show themselves as the width of the browser window changes.
- Fixing a search issue (pydata-sphinx-theme/1676) by adding a `role="main"`