### PR TITLE
[Doc Enhancement ]  Updating S3 doc page with example AWS Permissions Policies

### DIFF
--- a/ingesters/s3.md
+++ b/ingesters/s3.md
@@ -247,3 +247,140 @@ Some companies provide access to managed AWS regions that are technically AWS bu
 	S3-Force-Path-Style=true
 	File-Filters="auditlog/**/*.log"
 ```
+
+### AWS IAM Permission Policy
+
+Following the concept of least priviledge,  it is recommended to create a new AWS IAM user or role for the ingester to use with only the bare minimum required permissions.   Below are some example AWS Permissions policies that can be used for this newly created user.
+
+A basic permissions policy granting access to all S3 buckets on an account:
+
+```
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::*"
+		},
+		{
+			"Sid": "VisualEditor1",
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject",
+				"s3:GetObjectVersion"
+			],
+			"Resource": "arn:aws:s3:::*/*"
+		}
+	]
+}
+```
+
+A basic policy granting access to only a single S3 bucket on the account:
+
+```
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::<BUCKET_NAME>"
+		},
+		{
+			"Sid": "VisualEditor1",
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject",
+				"s3:GetObjectVersion"
+			],
+			"Resource": "arn:aws:s3:::<BUCKET_NAME>/*"
+		}
+	]
+}
+```
+
+A policy restricting access to only those systems with a specific originating IP address:
+
+
+```
+
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject",
+				"s3:GetObjectVersion"
+			],
+			"Resource": "arn:aws:s3:::*/*",
+			"Condition": {
+				"IpAddress": {
+					"aws:SourceIp": [
+						"10.0.0.1",
+						"192.168.0.1"
+					]
+				}
+			}
+		},
+		{
+			"Sid": "VisualEditor1",
+			"Effect": "Allow",
+			"Action": "s3:ListBucket",
+			"Resource": "arn:aws:s3:::*",
+			"Condition": {
+				"IpAddress": {
+					"aws:SourceIp": [
+						"10.0.0.1",
+						"192.168.0.1"
+					]
+				}
+			}
+		}
+	]
+}
+```
+
+A Policy allowing access to the Simple Queue Service for the SQS reader:
+
+```
+
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Sid": "VisualEditor0",
+			"Effect": "Allow",
+			"Action": [
+				"sqs:DeleteMessage",
+				"sqs:StartMessageMoveTask",
+				"sqs:GetQueueUrl",
+				"sqs:CancelMessageMoveTask",
+				"sqs:ChangeMessageVisibility",
+				"sqs:ListMessageMoveTasks",
+				"sqs:ReceiveMessage",
+				"sqs:SendMessage",
+				"sqs:GetQueueAttributes",
+				"sqs:ListQueueTags",
+				"sqs:ListDeadLetterSourceQueues",
+				"sqs:PurgeQueue",
+				"sqs:DeleteQueue",
+				"sqs:CreateQueue",
+				"sqs:SetQueueAttributes"
+			],
+			"Resource": "arn:aws:sqs:*:640150647918:*"
+		},
+		{
+			"Sid": "VisualEditor1",
+			"Effect": "Allow",
+			"Action": "sqs:ListQueues",
+			"Resource": "*"
+		}
+	]
+}
+
+```


### PR DESCRIPTION
Adding section with example AWS IAM Permissions policies to the s3.md wiki page.


This PR addresses a potential gap in documentation that can lead to client difficulties in syncing with their AWS Account.    No Issue was created.