### PR TITLE
[Documentation Enhancement ] Updated S3 Permissions policy SID

### DIFF
--- a/ingesters/s3.md
+++ b/ingesters/s3.md
@@ -259,13 +259,13 @@ A basic permissions policy granting access to all S3 buckets on an account:
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "VisualEditor0",
+			"Sid": "gravwellS3ListBucket",
 			"Effect": "Allow",
 			"Action": "s3:ListBucket",
 			"Resource": "arn:aws:s3:::*"
 		},
 		{
-			"Sid": "VisualEditor1",
+			"Sid": "gravwellS3GetObject",
 			"Effect": "Allow",
 			"Action": [
 				"s3:GetObject",
@@ -284,13 +284,13 @@ A basic policy granting access to only a single S3 bucket on the account:
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "VisualEditor0",
+			"Sid": "gravwellS3ListBucket",
 			"Effect": "Allow",
 			"Action": "s3:ListBucket",
 			"Resource": "arn:aws:s3:::<BUCKET_NAME>"
 		},
 		{
-			"Sid": "VisualEditor1",
+			"Sid": "gravwellS3GetObject",
 			"Effect": "Allow",
 			"Action": [
 				"s3:GetObject",
@@ -311,7 +311,7 @@ A policy restricting access to only those systems with a specific originating IP
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "VisualEditor0",
+			"Sid": "gravwellS3GetObject",
 			"Effect": "Allow",
 			"Action": [
 				"s3:GetObject",
@@ -328,7 +328,7 @@ A policy restricting access to only those systems with a specific originating IP
 			}
 		},
 		{
-			"Sid": "VisualEditor1",
+			"Sid": "gravwellS3ListBucket",
 			"Effect": "Allow",
 			"Action": "s3:ListBucket",
 			"Resource": "arn:aws:s3:::*",
@@ -353,7 +353,7 @@ A Policy allowing access to the Simple Queue Service for the SQS reader:
 	"Version": "2012-10-17",
 	"Statement": [
 		{
-			"Sid": "VisualEditor0",
+			"Sid": "gravwellSQS",
 			"Effect": "Allow",
 			"Action": [
 				"sqs:DeleteMessage",
@@ -375,7 +375,7 @@ A Policy allowing access to the Simple Queue Service for the SQS reader:
 			"Resource": "arn:aws:sqs:*:640150647918:*"
 		},
 		{
-			"Sid": "VisualEditor1",
+			"Sid": "gravwellSQSListQueues",
 			"Effect": "Allow",
 			"Action": "sqs:ListQueues",
 			"Resource": "*"


### PR DESCRIPTION
Replaced "Visual Editor" Sid names with more descriptive Gravwell naming within the example AWS Permission Policies

This PR addresses a lack of professional polish on the original example policies