### PR TITLE
Update versions.json for v5.4.4 release

### DIFF
--- a/_static/versions.json
+++ b/_static/versions.json
@@ -1,8 +1,12 @@
 [
   {
-    "name": "v5.4.3 (latest)",
-    "version": "v5.4.3",
+    "name": "v5.4.4 (latest)",
+    "version": "v5.4.4",
     "url": "https://docs.gravwell.io/",
     "preferred": true
+  },
+  {
+    "version": "v5.4.3",
+    "url": "https://docs.gravwell.io/v5.4.3/"
   }
 ]


### PR DESCRIPTION
This PR addresses no issue.

The version list must be updated prior to release to ensure that the version switcher in the docs behaves properly.