### PR TITLE
Don't show repeated links in sidebar menu

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -195,6 +195,19 @@ The styles below use media queries to dictate which of the 8 navbars will show g
   display: none;
 }
 
+/* When we've collapsed to the hamburger menu, only show the navbar that contains all 8 links */
+@media (width < 960px) {
+  #nav-1,
+  #nav-2,
+  #nav-3,
+  #nav-4,
+  #nav-5,
+  #nav-6,
+  #nav-7 {
+    display: none;
+  }
+}
+
 /* Depending on the width of the page, we decide which nav to show */
 
 @media (960px <= width < 1035px) {


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes a style change that hides all but the 8-link navbar when the window is less than 960px and the links are in the left sidebar.

This PR turns [this situation](https://github.com/gravwell/wiki/assets/108433848/7d52ac8b-2af5-4f61-9b1d-10594b4b8a51) into [this](https://github.com/gravwell/wiki/assets/108433848/205c838e-2694-4bd6-a396-69407d09ad25).
