### PR TITLE
Update truncate.md

### DIFF
--- a/search/truncate/truncate.md
+++ b/search/truncate/truncate.md
@@ -3,7 +3,7 @@
 The `truncate` module preserves only the first N characters (or bytes when using binary mode) of enumerated values. For example, to truncate all but the first 20 characters of the EV "Message":
 
 ```gravwell
-tag=data json IP Message | truncate -e Message 20 | table
+tag=data json IP Message | truncate Message 20 | table
 ```
 
 `truncate` only operates on string and byte slice enumerated values and by default assumes data is UTF-8 encoded. You can override this behavior by using the `-binary` flag.


### PR DESCRIPTION
Truncate does not support the `-e` flag, but rather takes the target EV as an argument