### PR TITLE
documenting Routed-Token-Type for HEC ingester

### DIFF
--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -317,7 +317,8 @@ The `HEC-Compatible-Listener` supports the following configuration parameters:
 | Routed-Token-Value | string array | NO       |                       | Token value used for authentication and tag routing.        |
 | Debug-Posts        | boolean      | NO       | false                 | Emit additional debugging info on the gravwell tag for each POST. |
 | Preprocessor       | string array | NO       |                       | Set of preprocessors to apply to entries.                   |
-| Attach-URL-Parameter | string array | NO       |      | Set of URL parameter values that will be attached to all entries in a request if they are found in the request URL. |
+| Attach-URL-Parameter | string array | NO     |      | Set of URL parameter values that will be attached to all entries in a request if they are found in the request URL. |
+| Token-Name         | string       | NO       |                       | Optional override of authentication token name, default is "Splunk". |
 
 ### Using the HEC-Compatible Listener
 
@@ -484,7 +485,7 @@ Consider the following configuration:
 
 Given the following curl request:
 ```
-curl -X POST -v http://example.gravwell.io/services/collector?tag=testing \
+curl -X POST -v http://example.gravwell.io/services/collector \
     -H "Authorization: Splunk supersekrettoken" -d '
     {"event": "invalid sourcetype things", "sourcetype": "things", "time": 1699034250}
     {"time": 1699034251, "sourcetype": "foo", "event": "valid sourcetype foo"}
@@ -519,6 +520,19 @@ tag=gravwell syslog Appname==httpingester Message == "HEC request" Hostname
 ```
 
 ![](hec_debug1.png)
+
+
+#### Token-Name
+
+Many third party services which are designed to send data to a HEC compatible listener have been observed sending authentication tokens with various random names; the default expected authentication header structure is `Authentication: Splunk <token>`, but we have seen everything from "User" to "user_name".  The `Token-Name` configuration parameter can override the Authorization header token name so that the HEC compatible listener can still authenticate and support third party services that doe not adhere to the HEC guidance.
+
+An example curl command that would authenticate with a `Token-Name` of `foobar` and a `TokenValue` of `soopersekrit` would be:
+
+```
+curl -X POST -v http://example.gravwell.io/services/collector \
+    -H "Authorization: foobar soopersekrit" -d '
+    {"event": "sample event", "time": 1699034250}
+```
 
 ## Health Checks
 

--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -524,7 +524,7 @@ tag=gravwell syslog Appname==httpingester Message == "HEC request" Hostname
 
 #### Token-Name
 
-Many third party services which are designed to send data to a HEC compatible listener have been observed sending authentication tokens with various random names; the default expected authentication header structure is `Authentication: Splunk <token>`, but we have seen everything from "User" to "user_name".  The `Token-Name` configuration parameter can override the Authorization header token name so that the HEC compatible listener can still authenticate and support third party services that doe not adhere to the HEC guidance.
+Many third party services which are designed to send data to a HEC compatible listener have been observed sending authentication tokens with various random names; the default expected authentication header structure is `Authentication: Splunk <token>`, but we have seen everything from "User" to "user_name".  The `Token-Name` configuration parameter can override the Authorization header token name so that the HEC compatible listener can still authenticate and support third party services that do not adhere to the HEC guidance.
 
 An example curl command that would authenticate with a `Token-Name` of `foobar` and a `TokenValue` of `soopersekrit` would be:
 

--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -469,7 +469,7 @@ The resulting entries will have the following tags:
 
 #### Routed-Token-Value
 
-The HEC compatible routes support routing data to specific tag based on the authentication token used; this can be especially useful for third party systems that do not support altering the default HEC URL.  A `Routed-Token-Value` enables multiple data sources to use the same HEC URL and still be routed to the appropriate tag even if the data producer is not providing sourcetype values in the request.  A `Routed-Token-Value` is used in the exact same way as a traditional HEC token when performing authentication; the HTTP HEC handler will determine the appropriate tag if no other overrides are present.  It is valid to combine a `Routed-Token-Value` with sourcetype overrides on specific entries and a default `TokenValue` is not required if at lease one `Routed-Token-Value` is specified.
+The HEC compatible routes support routing data to a specific tag based on the authentication token used; this can be especially useful for third-party systems that do not support altering the default HEC URL.  A `Routed-Token-Value` enables multiple data sources to use the same HEC URL and still be routed to the appropriate tag even if the data producer is not providing sourcetype values in the request.  A `Routed-Token-Value` is used in the exact same way as a traditional HEC token when performing authentication; the HTTP HEC handler will determine the appropriate tag if no other overrides are present.  It is valid to combine a `Routed-Token-Value` with sourcetype overrides on specific entries and a default `TokenValue` is not required if at lease one `Routed-Token-Value` is specified.
 
 Consider the following configuration:
 

--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -479,7 +479,7 @@ Consider the following configuration:
 	TokenValue="thisisyourtoken"
 	Tag-Name=stuff
 	Tag-Match="foo:bar"
-    Routed-Token-Value="supersekrettoken:baz"
+        Routed-Token-Value="supersekrettoken:baz"
 ```
 
 Given the following curl request:


### PR DESCRIPTION
Add documentation about the HTTP HEC `Routed-Token-Value`

This PR addresses https://github.com/gravwell/wiki/issues/913