### PR TITLE
backport fix for typo

### DIFF
--- a/search/directquery/directquery.md
+++ b/search/directquery/directquery.md
@@ -46,8 +46,8 @@ curl -X POST \
 ### JSON Object
 
 ```
-curl -X POST -H -d '{"SearchString":"tag=gravwell limit 10"}' \
-   "Gravwell-Token: aFOa_YbO7Pe0MAqK08PSD-oTrEZxopc5JBf0hu0W5_Vo-FxWsjHp" \
+curl -X POST -d '{"SearchString":"tag=gravwell limit 10"}' \
+   -H "Gravwell-Token: aFOa_YbO7Pe0MAqK08PSD-oTrEZxopc5JBf0hu0W5_Vo-FxWsjHp" \
    http://10.0.0.1/api/parse
 ```
 


### PR DESCRIPTION
This PR addresses no issue. Back port a fix for a typo. Fixed in `master` by https://github.com/gravwell/wiki/pull/942