### PR TITLE
Cleanup:  Updated Simple Relay docs to remove reference to only 2 reader types

### DIFF
--- a/ingesters/simple_relay.md
+++ b/ingesters/simple_relay.md
@@ -138,7 +138,7 @@ Simple relay supports the following types of basic readers which are useful in d
 * json
 * regex
 
-The basic listeners are specified via the "Listener" block and support line delimited and RFC5424 reader types.  Each Listener must have a unique name and a unique bind port (two different listeners cannot bind to the same protocol, address, and port).  The reader type for a basic listener is controlled by the "Reader-Type" parameter.  Currently there are two types of listeners (line and RFC5424).  If no Reader-Type is specified the line reader type is assumed.
+The basic listeners are specified via the "Listener" block and support line delimited and RFC5424 reader types.  Each Listener must have a unique name and a unique bind port (two different listeners cannot bind to the same protocol, address, and port).  The reader type for a basic listener is controlled by the "Reader-Type" parameter.  If no Reader-Type is specified the line reader type is assumed.
 
 Basic Listeners also require that each listener designate the tag the listener will apply to all incoming data via the "Tag-Name" parameter.  If the "Tag-Name" parameter is omitted, the "default" tag is applied.  The most basic listener named "test" which expects line broken data on TCP port 5555 and applies the tag "testing" would have the following configuration specification:
 


### PR DESCRIPTION
Removed "Currently there are two types of listeners (line and RFC5424)." from line 141 as additional Reader types have been added.

