### PR TITLE
Add workflow to build HTML

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -1,0 +1,54 @@
+name: "Build HTML"
+on: workflow_dispatch
+env:
+  HTML_BUILD: docs_${{github.sha}}.tar.gz
+jobs:
+  html-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Build and package documentation
+        run: |
+          # Fail on any error
+          set -e
+
+          # Make temporary location for build results
+          export BUILD_DEST="$( mktemp --directory --tmpdir=${{ runner.temp }} )"
+
+          # Fetch all remote refs
+          git fetch --all
+
+          # Pull latest from main branch
+          git checkout master
+          git pull
+
+          # There should only be one marked "preferred": the latest release
+          cat _static/versions.json | jq -r 'map(select(.preferred)) | length | if . != 1 then ("exactly one version should be marked preferred\n" | halt_error(1)) else "ok" end '
+
+          # Build and copy to build destination
+          nix-build
+          cp -r ./result/html $BUILD_DEST
+          chmod --recursive +w $BUILD_DEST
+
+          # Checkout and build each non-latest version listed in versions.json. Then copy them to build destination.
+          for v in $(cat _static/versions.json | jq -r 'map(select(.preferred != true)) | map(.version) | join(" ")')
+          do
+              git checkout release/$v
+              git pull
+              nix-build
+              cp -r ./result/html $BUILD_DEST/html/$v
+              chmod --recursive +w $BUILD_DEST
+          done
+
+          tar -C $BUILD_DEST -czf ${{ env.HTML_BUILD }} html
+      - name: Upload HTML Build
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: wiki-build
+          path: ${{ env.HTML_BUILD }}
+          if-no-files-found: error
+          retention-days: 0

--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload HTML Build
         uses: actions/upload-artifact@v4.3.1
         with:
-          name: wiki-build
+          name: docs_${{github.sha}}
           path: ${{ env.HTML_BUILD }}
           if-no-files-found: error
           retention-days: 0

--- a/conf.py
+++ b/conf.py
@@ -42,7 +42,14 @@ myst_enable_extensions = [
 
 
 templates_path = ["_templates"]
-exclude_patterns = ["README.md", "_build", "Thumbs.db", ".DS_Store", "env", "_vendor"]
+exclude_patterns = [
+    "README.md",
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "env",
+    "_vendor",
+]
 
 language = "en"
 


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes adding a manually-dispatched workflow that deposits a multi-version, HTML build of the docs as an artifact on GitHub.

Note that this PR must be merged to the default branch of this repository before the workflow becomes available for dispatch. That said, I've executed this workflow on my fork. You can see what the outcome looks like over there: https://github.com/michael-wisely-gravwell/wiki/actions/runs/8900711566