### PR TITLE
Remove pretty_* functions that should not be included until 5.5.0

### DIFF
--- a/search/eval/eval.md
+++ b/search/eval/eval.md
@@ -436,36 +436,6 @@ Returns the input with all leading and trailing whitespace removed.
 
 Returns the input with the trailing suffix removed.
 
-#### pretty_size
-
-    function pretty_size(input string) string
-
-Converts a number to an abreviated pretty printed size, 1234567 becomes "1.18 MB".
-
-#### pretty_count
-
-    function pretty_count(input string) string
-
-Converts a number to an abreviated pretty printed magnitude, 1234567 becomes "1.24 M".
-
-#### pretty_count
-
-    function pretty_count(input string) string
-
-Converts a number to an abreviated pretty printed magnitude, 1234567 becomes "1.24 M".
-
-#### pretty_rate
-
-    function pretty_rate(number, duration) string
-
-Converts a number to an abreviated pretty printed rate in bytes, kilobytes, or megabytes per second given a magnitude and duration; "pretty_rate(1234567, "2s")" becomes "588.87 KB/s".
-
-#### pretty_line_rate
-
-    function pretty_line_rate(number, duration) string
-
-Converts a number to an abreviated pretty printed line rate in bits, kilobits, and megabits per second given a magnitude and duration; "pretty_line_rate(1234567, "2s")" becomes "4.71 Mb/s".
-
 ### Hash
 
 #### hash_md5


### PR DESCRIPTION
This PR addresses no issue, but it came to my attention because https://github.com/gravwell/wiki/issues/1007 was submitted. I was looking to see if the duplicate `pretty_count` should just be removed or if it was a copy/paste error that was intended to be edited into some other `pretty_*` function. It looks like all of the `pretty_*` functions were documented, but it got published too soon. 