### PR TITLE
Release/v5.4.6: Fix HTTP ingester token name

### DIFF
--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -528,7 +528,7 @@ tag=gravwell syslog Appname==httpingester Message == "HEC request" Hostname
 
 #### Token-Name
 
-Many third party services which are designed to send data to a HEC compatible listener have been observed sending authentication tokens with various random names; the default expected authentication header structure is `Authentication: Splunk <token>`, but we have seen everything from "User" to "user_name".  The `Token-Name` configuration parameter can override the Authorization header token name so that the HEC compatible listener can still authenticate and support third party services that do not adhere to the HEC guidance.
+Many third party services which are designed to send data to a HEC compatible listener have been observed sending authentication tokens with various random names; the default expected authentication header structure is `Authorization: Splunk <token>`, but we have seen everything from "User" to "user_name".  The `Token-Name` configuration parameter can override the Authorization header token name so that the HEC compatible listener can still authenticate and support third party services that do not adhere to the HEC guidance.
 
 An example curl command that would authenticate with a `Token-Name` of `foobar` and a `TokenValue` of `soopersekrit` would be:
 


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/wiki/issues/1034