### PR TITLE
pretty functions with duplicate removed

### DIFF
--- a/search/eval/eval.md
+++ b/search/eval/eval.md
@@ -436,6 +436,30 @@ Returns the input with all leading and trailing whitespace removed.
 
 Returns the input with the trailing suffix removed.
 
+#### pretty_size
+
+    function pretty_size(input string) string
+
+Converts a number to an abreviated pretty printed size, 1234567 becomes "1.18 MB".
+
+#### pretty_count
+
+    function pretty_count(input string) string
+
+Converts a number to an abreviated pretty printed magnitude, 1234567 becomes "1.24 M".
+
+#### pretty_rate
+
+    function pretty_rate(number, duration) string
+
+Converts a number to an abreviated pretty printed rate in bytes, kilobytes, or megabytes per second given a magnitude and duration; "pretty_rate(1234567, "2s")" becomes "588.87 KB/s".
+
+#### pretty_line_rate
+
+    function pretty_line_rate(number, duration) string
+
+Converts a number to an abreviated pretty printed line rate in bits, kilobits, and megabits per second given a magnitude and duration; "pretty_line_rate(1234567, "2s")" becomes "4.71 Mb/s".
+
 ### Hash
 
 #### hash_md5


### PR DESCRIPTION
This PR addresses https://github.com/gravwell/wiki/issues/1007

These functions were published too soon due to some unplanned patch releases. The functions were [removed from the documentation](https://github.com/gravwell/wiki/pull/1009) pending the 5.5.0 release. When these functions were originally documented, `pretty_count` was mistakenly listed twice. That duplicate has been removed in this PR.