### PR TITLE
construct a robots.txt file during build

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -42,6 +42,7 @@ jobs:
               nix-build
               cp -r ./result/html $BUILD_DEST/html/$v
               chmod --recursive +w $BUILD_DEST
+              echo "Disallow: /$v/" >> $BUILD_DEST/html/robots.txt
           done
 
           tar -C $BUILD_DEST -czf ${{ env.HTML_BUILD }} html


### PR DESCRIPTION
During the build sequence construct a `robots.txt` file that instructs crawlers to ignore all our historical version sub directories.

This PR addresses https://github.com/gravwell/wiki/issues/838