### PR TITLE
ci: Use jdupes to deduplicate build

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -16,6 +16,9 @@ jobs:
           # Fail on any error
           set -e
 
+          # Install relevant tools
+          sudo apt-get install -y jdupes
+
           # Make temporary location for build results
           export BUILD_DEST="$( mktemp --directory --tmpdir=${{ runner.temp }} )"
 
@@ -44,6 +47,9 @@ jobs:
               chmod --recursive +w $BUILD_DEST
               echo "Disallow: /$v/" >> $BUILD_DEST/html/robots.txt
           done
+
+          # Replace duplicates with soft links
+          jdupes --recurse --link-soft $BUILD_DEST
 
           tar -C $BUILD_DEST -czf ${{ env.HTML_BUILD }} html
       - name: Upload HTML Build


### PR DESCRIPTION
This PR addresses no issue.

A full wiki build includes multiple versions of the Gravwell docs. Each version is different, but much of the content is the same.

This PR proposes using [`jdupes`](https://manpages.debian.org/bookworm/jdupes/jdupes.1.en.html) to find duplicate files and replace them with soft links. By replacing copies with links, this PR aims to reduce the size of builds.

The workflow changes won't be available until this PR is merged to `main`. Until then, one can see the proposed workflow run on my fork: https://github.com/michael-wisely-gravwell/wiki/actions/runs/10690709826/job/29635873170

Note that the built artifact is [201 MB](https://github.com/michael-wisely-gravwell/wiki/actions/runs/10690709826) with de-duplication compared to [2.01 GB](https://github.com/gravwell/wiki/actions/runs/10583813892) without it.