### PR TITLE
ci: Pr automations

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,16 @@
+jobs:
+  update-pr-labels:
+    name: Update PR Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR Labels
+        uses: "gravwell/pr-labels@v1"
+        with:
+          GITHUB_TOKEN: "${{ github.token }}"
+name: Update PR Labels
+on:
+  pull_request_target: {}
+  push: {}
+permissions:
+  contents: read
+  pull-requests: write

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,47 @@
+jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Echo (some of) github context"
+        run: |
+          echo ${{ github.repository }}
+          echo ${{ github.ref }}
+          echo ${{ github.ref_name }}
+
+  sync:
+    # Avoid running sync jobs on forks
+    if: "${{ github.repository == 'gravwell/wiki' }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        branches:
+          - source_pattern: main
+            target_pattern: next-patch
+
+          - source_pattern: next-patch
+            target_pattern: next-minor
+
+          - source_pattern: next-minor
+            target_pattern: next-major
+
+    name: "${{ matrix.branches.source_pattern }} => ${{ matrix.branches.target_pattern }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open/Update PR
+        id: sync-branches
+        uses: "gravwell/sync-branches@v1"
+        with:
+          GITHUB_TOKEN: "${{ github.token }}"
+          source_pattern: ${{ matrix.branches.source_pattern }}
+          target_pattern: ${{ matrix.branches.target_pattern }}
+          use_intermediate_branch: "True"
+          source_conflict_label: "src conflict"
+          target_conflict_label: "conflict"
+
+name: Sync branches
+on:
+  push: {}
+permissions:
+  contents: write
+  pull-requests: write


### PR DESCRIPTION
This PR addresses no issue.

This PR proposes adding two automations:

- `Update PR Labels`
  - adds a "behind" label to a PR when its head (source) branch falls behind its base (target) branch
  - adds a "conflict" label to a PR when its head (source) branch is in conflict with its base (target) branch
- `Sync Branches`
  - Opens PRs to keep branches in sync:
    - main => next-patch
    - next-patch => next-minor
    - next-minor => next-major

### TODO

- [x] Make sure labels exist