### PR TITLE
fix: Use env var to determine version list

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -23,6 +23,12 @@ copyright = f"Gravwell, Inc. {date.today().year}"
 author = "Gravwell, Inc."
 release = "v5.4.3"
 
+# Default to localhost:8000, so the version switcher looks OK on livehtml
+version_list_url = os.environ.get(
+    "VERSION_LIST_URL", "http://localhost:8000/_static/versions.json"
+)
+print("Using version_list_url:", version_list_url)
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
@@ -96,7 +102,7 @@ html_theme_options = {
     # Version switcher
     #
     "switcher": {
-        "json_url": "https://docs.gravwell.io/_static/versions.json",
+        "json_url": version_list_url,
         # The `version` field of each entry in verions.json must match a vN.N.N release name
         "version_match": release,
     },

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+{ VERSION_LIST_URL ? null }:
 let
   # use a specific (although arbitrarily chosen) version of the Nix package collection
   pkgs = import (fetchTarball {
@@ -65,6 +66,8 @@ let
 in pkgs.stdenv.mkDerivation {
   name = "gravwell-wiki";
   src = ./.;
+
+  VERSION_LIST_URL = VERSION_LIST_URL;
 
   buildInputs = [ pythonBundle pkgs.gnumake pkgs.git custom-aspell ];
   buildPhase = ''


### PR DESCRIPTION
This PR addresses no issue.

We currently have odd behavior on the deployed GitHub Pages site, where visiting v5.5.5 or older versions of the docs will cause the version switcher to stop working.

This happens because old versions of the docs have `https://docs.gravwell.io/_static/versions.json` hard-coded as the location for the version list. When we load the page from deployed GitHub Pages, the docs attempt a cross-domain fetch to `docs.gravwell.io`, which is not allowed.

This PR proposes updating previous releases of the docs to accept the `VERSION_LIST_URL` variable from Actions. This gives us control over where **every** version of the docs looks for the version list.

I've already applied this idea to my fork of the wiki (https://michael-wisely-gravwell.github.io/wiki/v5.4.5/index.html). The version switcher appears to behave as expected over there.

Unfortunately, this change will need to bubble up past releases, but on the bright side, CI is fast on the wiki :)