### PR TITLE
ci: Use WikiBuilder runner for HTML builds

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   html-build:
     name: Build HTML
-    runs-on: ubuntu-latest
+    runs-on: WikiBuilder
     steps:
       - uses: actions/checkout@v4
       - name: Setup Nix


### PR DESCRIPTION
This PR addresses no issue.

We got a warning about disk space on the last build.

This PR proposes using a large runner that has a lot more disk.