### PR TITLE
Only trigger on branch push

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -41,7 +41,8 @@ jobs:
 
 name: Sync branches
 on:
-  push: {}
+  push:
+    branches: '**'
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
This PR addresses no issue.

We're running the sync-branches automation on tag pushes as well as branch pushes

https://github.com/gravwell/wiki/actions/runs/11806541671

![image](https://github.com/user-attachments/assets/a8e0edb6-66c3-4e4f-9066-6a2a3166586f)

This PR proposes limiting to only branches, per the above error message.