### PR TITLE
add note about timestamp truncation. Remove erroneous statement about compound queries.

### DIFF
--- a/gui/queries/queries.md
+++ b/gui/queries/queries.md
@@ -44,7 +44,7 @@ The queries stored in the query library are also available through the right-han
 ## Selecting a Timeframe
 
 ```{note}
-Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically truncated to the closest second.
+Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically rounded down to the second.
 ```
 
 By default, queries run over the last hour of data. This is easily changed by clicking on the calendar icon or timeframe above the query and selecting a timeframe from the dropdown:

--- a/gui/queries/queries.md
+++ b/gui/queries/queries.md
@@ -43,6 +43,10 @@ The queries stored in the query library are also available through the right-han
 (timeframe_selector)=
 ## Selecting a Timeframe
 
+```{note}
+Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically truncated to the closest second.
+```
+
 By default, queries run over the last hour of data. This is easily changed by clicking on the calendar icon or timeframe above the query and selecting a timeframe from the dropdown:
 
 ![](timeframe-icon.png)

--- a/search/search.md
+++ b/search/search.md
@@ -286,7 +286,7 @@ If start/end time constraints are provided, the GUI time picker timeframe will b
 ```
 
 ```{note}
-Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically truncated to the closest second.
+Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically rounded down to the second.
 ```
 
 ## Comments

--- a/search/search.md
+++ b/search/search.md
@@ -285,6 +285,10 @@ start="2006-01-02T15:04:05Z" end=-1h tag=default json foo table
 If start/end time constraints are provided, the GUI time picker timeframe will be ignored.
 ```
 
+```{note}
+Timeframes are always aligned to one second boundaries. Sub-second timeframes will be automatically truncated to the closest second.
+```
+
 ## Comments
 
 Gravwell supports two types of comments. 

--- a/search/search.md
+++ b/search/search.md
@@ -285,10 +285,6 @@ start="2006-01-02T15:04:05Z" end=-1h tag=default json foo table
 If start/end time constraints are provided, the GUI time picker timeframe will be ignored.
 ```
 
-```{note}
-The start/end constraints cannot be used in the inner query portion of compound queries. Only the main query can use these constraints.
-```
-
 ## Comments
 
 Gravwell supports two types of comments. 


### PR DESCRIPTION
Fixes #1296
