### PR TITLE
Fix links in regex docs

### DIFF
--- a/search/regex/regex.md
+++ b/search/regex/regex.md
@@ -283,7 +283,7 @@ Flag syntax is `xyz` (set) or `-xyz` (clear) or `xy-z` (set `xy`, clear
 `[\p{Name}]` |   named Unicode property inside character class (≡ `\p{Name}`)
 `[^\p{Name}]`|   named Unicode property inside negated character class (≡ `\P{Name}`)
 
-
+(perl)=
 |     |  Perl character classes (all ASCII-only)
 |------|------------------------------------------------
 `\d` |  digits (≡ `[0-9]`)
@@ -297,6 +297,7 @@ Flag syntax is `xyz` (set) or `-xyz` (clear) or `xy-z` (set `xy`, clear
 `\v` |  vertical space [(NOT SUPPORTED)]
 `\V` |  not vertical space [(NOT SUPPORTED)]
 
+(ascii)=
 |                | ASCII character classes
 |----------------|----------------------------------------------------------------------------------
 `[[:alnum:]]` |   alphanumeric (≡ `[0-9A-Za-z]`)


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. 
https://github.com/gravwell/wiki/pull/1300 added some new documentation to the regex page.
When reviewing an unrelated PR, I checked it out and built the docs locally. I got a warning about these two missing cross-reference targets. After adding the cross-references, the docs build with 0 warnings.