### PR TITLE
fix: Reduce search match score on changlog docs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -73,6 +73,7 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_extra_path = ["open_source"]
 html_css_files = ["css/custom.css"]
+html_search_scorer = "search_scorer.js"
 html_theme_options = {
     "logo": {
         "image_light": "_static/images/Gravwell-Color.svg",

--- a/search_scorer.js
+++ b/search_scorer.js
@@ -1,0 +1,27 @@
+// There's a race in setting the scorer, depending on order in which files are loaded.
+// This definition omits a "var", "let" or "const" because there's a chance Scorer is already defined.
+// By omitting the keyword, we can define or set the value of the variable, which is handy.
+Scorer = {
+  score: (result) => {
+    const [docname, title, anchor, descr, score, filename] = result;
+    if (docname.startsWith("changelog/")) {
+      // Push matches on changelogs to the bottom
+      return score - 100;
+    }
+    return score;
+  },
+
+  // Default values. See https://github.com/sphinx-doc/sphinx/blob/5ff3740063c1ac57f17ecd697bcd06cc1de4e75c/sphinx/themes/basic/static/searchtools.js#L10
+  objNameMatch: 11,
+  objPartialMatch: 6,
+  objPrio: {
+    0: 15,
+    1: 5,
+    2: -5,
+  },
+  objPrioDefault: 0,
+  title: 15,
+  partialTitle: 7,
+  term: 5,
+  partialTerm: 2,
+};


### PR DESCRIPTION
This PR addresses no issue.

Changelogs often clutter search results, making it challenging to find what one is looking for. Consider what happens when I search for "ingester": [Seven rows of Changelog matches push the match for the "Ingesters" page out of view.](https://github.com/user-attachments/assets/73ae1c84-7eec-4406-b1c6-dfd15cd671d5)

This PR proposes using a Sphinx [search scorer](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_search_scorer) to lower the score of any changelog match.

I chose to reduce the changelog score by 100 because I was seeing Changelog matches with scores in the 70s. Reducing by 100 [doesn't eliminate the changelogs from search results](https://github.com/user-attachments/assets/1653e5ac-4ef9-4eb7-95d6-9a9da1ee5d46) (I think that would be a mistake), but it does push them to the bottom of the results list.
