### PR TITLE
Release/v5.7.0: Change header levels for hotfix

### DIFF
--- a/changelog/5.7.0.md
+++ b/changelog/5.7.0.md
@@ -29,9 +29,9 @@
 * Fixed an issue where intermediate tag translation would quietly roll over to tag 0.
 * Fixed an issue with dangling GIDs that could cause problems with group sharing.
 
-# 5.7.0-2 Hotfix
+## 5.7.0-2 Hotfix
 
-## Released 05 February 2025
+### Released 05 February 2025
 
-### Bug Fixes
+#### Bug Fixes
 * Fixed an issue where Alert sharing permissions were not restored from backups. Please note that the sharing information ***is*** preserved when creating the backup. 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue. 
Change the header levels for the hotfix in the 5.7.0 changelog because I don't think we need to maintain separate links to the same changelog page on the list page. I don't think we need to tag and re-deploy the 5.7.0 documentation just for this, but I want to correct if for when we do the next patch release.

![image](https://github.com/user-attachments/assets/7bf7e60b-f65e-4e88-bbab-7e6384cae19b)