### PR TITLE
fix example in HEC compatible HTTP ingester section

### DIFF
--- a/configuration/replication.md
+++ b/configuration/replication.md
@@ -122,7 +122,7 @@ Replication is controlled by the "Replication" configuration group in the gravwe
 | Disable-Server | Disable-Server=true | Disable the indexer replication server, it will only act as a client.  This is important when using offline replication. | 
 | Disable-Compression | Disable-Compression=true | Disable compression on the storage for the replicated data. |
 | Enable-Transparent-Compression | Enable-Transparent-Compression=true | Enable transparent compression on using the host filesystem for replicated data. |
-| Enable-Transport-Compression | Enable-Transparent-Compression=true | Enable transport compression when transmitting data to replication peer.  Defaults to `true`. |
+| Enable-Transport-Compression | Enable-Transparent-Compression=true | Enable transport compression when transmitting data to replication peer.  Defaults to `false`. |
 
 ## Disabling Replication Per Well
 

--- a/ingesters/http.md
+++ b/ingesters/http.md
@@ -346,7 +346,7 @@ curl "http://example.org/services/collector" -H "Authorization: Splunk thisisyou
 You can also send raw strings, rather than JSON-formatted events, by appending `/raw` to the URL:
 
 ```
-curl "http://example.org/services/collector" -H "Authorization: Splunk thisisyourtoken" \
+curl "http://example.org/services/collector/raw" -H "Authorization: Splunk thisisyourtoken" \
 -d 'here is some raw data'
 ```
 


### PR DESCRIPTION
also bring in the change in replication defaults from main due to an earlier PR that went to the wrong branch


Example doesn't use the URL we mention:
![image](https://github.com/user-attachments/assets/5fda681e-84bf-45a7-8a8c-55955b51d012)
