### PR TITLE
add ageout global time override documentation

### DIFF
--- a/configuration/ageout.md
+++ b/configuration/ageout.md
@@ -85,9 +85,15 @@ An example configuration in which data is moved from the hot pool to the cold po
 In the above configuration, data will be deleted permanently when the entry timestamps are 90 days old, having spent 7 days in the hot pool and 83 days in the cold pool.  The `Hot-Duration` and `Cold-Duration` values are not cumulative; they specify the maximum age of entries.
 ```
 
-The Time based ageout is invoked once per day, sweeping each pool for shards that can be aged out.  By default the sweep happens at midnight UTC, but the execution time can be overridden in the well configuration with the Ageout-Time-Override directive.  The override directive is specified in 24 hour UTC time.
+The Time based ageout is invoked once per day, sweeping each pool for shards that can be aged out. By default the sweep happens at midnight UTC, but the default time can be changed globally using the `Default-Ageout-Time` parameter in the `[Global]` section of the configuration file. Individual wells can further override this using the `Ageout-Time-Override` directive in the well configuration. Both directives are specified in 24-hour UTC time.
 
-An example configuration that overrides the ageout time checks to occur at 7PM UTC:
+An example global configuration that sets the default ageout time to 3AM UTC for all wells:
+```
+[Global]
+	Default-Ageout-Time=03:00
+```
+
+An example well configuration that overrides the ageout time checks to occur at 7PM UTC for a specific well:
 ```
 [Storage-Well "syslog"]
 	Location=/mnt/xpoint/gravwell/syslog

--- a/configuration/parameters.md
+++ b/configuration/parameters.md
@@ -693,6 +693,12 @@ Applies to: Indexer
 Default Value: 1  
 Example: `Ditto-Max-Workers=8`  
 Description: Sets the number of parallel worker processes for [Ditto](/configuration/ditto) transfers.
+
+### **Default-Ageout-Time**
+Applies to:		Indexer  
+Default Value:	`00:00` (midnight UTC)  
+Example:		`Default-Ageout-Time=03:00`  
+Description:	Sets the default time of day (in 24-hour UTC format) at which time-based ageout is performed for all wells. By default, time-based ageout occurs at midnight UTC. Individual wells can override this default using the `Ageout-Time-Override` directive. See the [ageout documentation](/configuration/ageout) for more information.
  
 ## AI
 
@@ -860,9 +866,9 @@ Example:		`Enable-Transparent-Compression=true`
 Description:	These parameters control kernel-level, transparent compression of data in the wells. If enabled, Gravwell can instruct the `btrfs` filesystem to transparently compress data. This is more efficient than user-mode compression. Setting `Enable-Transparent-Compression` true automatically turns off user-mode compression. Note that setting `Disable-Compression=true` will **disable** transparent compression.
 
 #### **Ageout-Time-Override**
-Default Value:  
-Example:		`Ageout-Time-Override="3:00AM"`  
-Description:	This parameter allows you to specify a particular time at which the ageout routine should run. This is typically not needed.
+Default Value:	(inherits from `Default-Ageout-Time` global parameter, or midnight UTC if not set)  
+Example:		`Ageout-Time-Override=19:00`  
+Description:	This parameter allows you to specify a particular time (in 24-hour UTC format) at which the ageout routine should run for this well, overriding the global `Default-Ageout-Time` setting. See the [ageout documentation](/configuration/ageout) for more information.
 
 ### Acceleration Options
 


### PR DESCRIPTION
This PR adds documentation for https://github.com/gravwell/issues/issues/2035. 

It adds documentation for setting global default time of day for the ageout routine.
