### PR TITLE
Add docs on supported browsers.

### DIFF
--- a/quickstart/quickstart.md
+++ b/quickstart/quickstart.md
@@ -136,7 +136,7 @@ You can estimate your storage requirements using the following calculator:
 
 ## Browser Support
 
-To keep Gravwell fast and secure, we adhere to standards set by **Angular 21**, a web application framework. This means we focus on "evergreen" browsers. The browsers that auto-update and stay modern.
+To keep Gravwell fast and secure, we adhere to standards set by the Angular web application framework. This means we focus on "evergreen" browsers. The browsers that auto-update and stay modern.
 
 [Read more](https://v21.angular.dev/reference/versions#browser-support)
 


### PR DESCRIPTION
This PR supports necessary changes that have came from https://github.com/gravwell/issues/issues/1988.

## This PR proposes...

- Adding a new docs page detailing our browser support.

## Questions...

- [x] Should this page be linked in anywhere else on the docs?
    - Browser support is now embedded within the quickstart page. Not its own page (the page was pretty sparse).