### PR TITLE
chore(nix): only set LOCALE_ARCHIVE if on Linux

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -97,5 +97,7 @@ in pkgs.stdenv.mkDerivation {
     cp -r _build/html $out
   '';
 
-  LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
+  LOCALE_ARCHIVE = if pkgs.stdenv.isLinux 
+    then "${pkgs.glibcLocales}/lib/locale/locale-archive" 
+    else "";
 }


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

## This PR proposes...

- only setting `LOCALE_ARCHIVE` environment variable if running `nix-shell` on Linux

Without this change, macOS builds of nix environment fail with the following error:

```bash
$ nix-shell
copying path '/nix/store/fjvkr94j3lwca8y66zccn15rjwzqn0rd-source' from 'https://cache.nixos.org'...
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'gravwell-wiki'
         whose name attribute is located at /nix/store/fjvkr94j3lwca8y66zccn15rjwzqn0rd-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'LOCALE_ARCHIVE' of derivation 'gravwell-wiki'
         at /Users/tyler.elton/code/wiki/default.nix:100:3:
           99|
          100|   LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
             |   ^
          101| }

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: cannot coerce null to a string: null
``` 

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
  - n/a 
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).
  - n/a 

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
