### PR TITLE
Update upload-pages-artifact action to v5.0.0

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -100,7 +100,7 @@ jobs:
           echo "BUILD_DEST=${BUILD_DEST}" >> "$GITHUB_ENV"
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: "${{ env.BUILD_DEST }}/html"
 


### PR DESCRIPTION
<!-- 

The title of this PR should have the form:  [TYPE]([ISSUE_NUMBER]): [CHANGELOG_MESSAGE]

- If [TYPE] is fix or feat, the CHANGELOG_MESSAGE will be included in customer-facing, release change logs. 
- Other [TYPE]s WILL NOT be included in release change logs. 
- Check out https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type for other type ideas, or invent your own. 

-->

This PR addresses no issue.

I noticed that the docs deployment for 5.8.14 had a Node 20 warning for `actions/upload-artifact`: https://github.com/gravwell/wiki/actions/runs/24861507586

We're getting that warning because `actions/upload-pages-artifact` is built using `actions/upload-artifact`. `actions/upload-pages-artifact` version 5 [bumps to a newer version of `actions/upload-artifact`](https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0), which uses a [newer version of Node](https://github.com/actions/upload-artifact/blob/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f/action.yml).

## This PR proposes...

- Upgrading to `actions/upload-pages-artifact` version 5.0.0 
  - https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0

## PR Tasks

<!-- Add tasks to this list as needed -->

- ~~e2e and/or unit tests included. If not, please provide an explanation.~~
- ~~**Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).~~

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- ~~e2e or unit tests are present to test the proposed changes.~~
- [x] Code is sufficiently documented.
- [x] Code meets quality and correctness expectations.
