### PR TITLE
Feat: update mentions of backticks in playbook docs.

### DIFF
--- a/gui/playbooks/playbooks.md
+++ b/gui/playbooks/playbooks.md
@@ -39,12 +39,12 @@ The final icon lets you set editor options such as the font size and the theme:
 Playbooks are written in [Markdown](https://www.markdownguide.org/basic-syntax/). The basic structures (headings, italics, bold, links, lists, etc.) are available and, for convenience, are also available via icons at the top of the editor pane.
 
 ```{note}
-The only major caveat of the Markdown used for playbooks is that code blocks (text wrapped in backticks, triple backticks, or indented by at least 4 spaces/1 tab) are considered *queries*; Gravwell will attempt to parse the contents of the code block as a Gravwell query. To insert plain unformatted text, use HTML `pre` tags.
+The only major caveat of the Markdown used for playbooks is that code blocks (text wrapped in triple backticks or indented by at least 4 spaces/1 tab) are considered *queries*; Gravwell will attempt to parse the contents of the code block as a Gravwell query. To insert plain unformatted text, use HTML `pre` tags.
 ```
 
 ## Inserting Queries
 
-You can insert runnable queries by wrapping the query text in triple backticks or single backticks, or by indenting it at least 4 spaces / 1 tab:
+You can insert runnable queries by wrapping the query text in triple backticks or by indenting it at least 4 spaces / 1 tab:
 
 ![](queries.png)
 


### PR DESCRIPTION
This PR relates to:

- https://github.com/gravwell/kits/issues/292
- https://github.com/gravwell/issues/issues/2317

## This PR proposes...

- Removing mentions of single backticks rendering launchable queries.
    - Single backticks are now used for the standard markdown behavior of rendering inline monospace text.

## PR Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e and/or unit tests included. If not, please provide an explanation.
- [ ] **Bug fixes only:** minimal repro steps included on the issue (for PR QA + Release QA).

## Reviewer Tasks

<!-- Add tasks to this list as needed -->

- [ ] e2e or unit tests are present to test the proposed changes.
- [ ] Code is sufficiently documented.
- [ ] Code meets quality and correctness expectations.
